### PR TITLE
fix: move conventional commits validation settings to branch block in CI/CD config defaults

### DIFF
--- a/.boilerplate/inputs.yaml
+++ b/.boilerplate/inputs.yaml
@@ -31,11 +31,12 @@ repositories: [] # (Optional) Repository specifications to create and configure.
 #        dist: "temurin" # (Optional) Runtime distribution when supported. Default: template-specific.
 #      sonarqube: # (Optional) SonarQube integration settings. Default: enabled by template.
 #        disabled: false # (Optional) Disable SonarQube when true. Default: false.
-#      branch: # (Optional) Branch-protection rendering settings. Default: protection enabled.
+#      branch: # (Optional) Branch-protection rendering settings. Default: protection enabled, Conventional Commits validation disabled.
 #        protectionEnabled: true # (Optional) Render branch-protection configuration into the CI/CD config. Default: true.
-#      enforce: # (Optional) Commit-message enforcement settings rendered into the CI/CD config. Default: enforcement disabled.
-#        conventionalCommitsEnabled: false # (Optional) Enforce Conventional Commits messages when true. Default: false.
+#        conventionalCommitsEnabled: false # (Optional) Enable Conventional Commits message validation on protected branches. Default: false.
 #        conventionalCommitsPattern: "^(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\([a-z0-9\\-]+\\))?: .+" # (Optional) Regex used to validate Conventional Commits messages. Default: shown value.
+#      enforce: # (Optional) Commit-message enforcement settings rendered into the CI/CD config. Default: enforcement disabled.
+#        conventionalCommitsEnforced: false # (Optional) Enforce (block) commits that do not match the Conventional Commits pattern when true. Default: false.
 #        customCommitsPatternEnabled: false # (Optional) Enforce a custom commit-message pattern when true. Default: false.
 #        customCommitsPattern: "PROJECT-[0-9]+.+" # (Optional) Regex used to validate custom commit messages, e.g. requiring an issue key. Default: shown value.
 #      dependency_track: # (Optional) Dependency-Track integration settings. Default: enabled by template.

--- a/README.md
+++ b/README.md
@@ -329,8 +329,8 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | 6.4.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.12.1 |
+| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -125,11 +125,12 @@ repositories: [] # (Optional) Repository specifications to create and configure.
 #        dist: "temurin" # (Optional) Runtime distribution when supported. Default: template-specific.
 #      sonarqube: # (Optional) SonarQube integration settings. Default: enabled by template.
 #        disabled: false # (Optional) Disable SonarQube when true. Default: false.
-#      branch: # (Optional) Branch-protection rendering settings. Default: protection enabled.
+#      branch: # (Optional) Branch-protection rendering settings. Default: protection enabled, Conventional Commits validation disabled.
 #        protectionEnabled: true # (Optional) Render branch-protection configuration into the CI/CD config. Default: true.
-#      enforce: # (Optional) Commit-message enforcement settings rendered into the CI/CD config. Default: enforcement disabled.
-#        conventionalCommitsEnabled: false # (Optional) Enforce Conventional Commits messages when true. Default: false.
+#        conventionalCommitsEnabled: false # (Optional) Enable Conventional Commits message validation on protected branches. Default: false.
 #        conventionalCommitsPattern: "^(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\([a-z0-9\\-]+\\))?: .+" # (Optional) Regex used to validate Conventional Commits messages. Default: shown value.
+#      enforce: # (Optional) Commit-message enforcement settings rendered into the CI/CD config. Default: enforcement disabled.
+#        conventionalCommitsEnforced: false # (Optional) Enforce (block) commits that do not match the Conventional Commits pattern when true. Default: false.
 #        customCommitsPatternEnabled: false # (Optional) Enforce a custom commit-message pattern when true. Default: false.
 #        customCommitsPattern: "PROJECT-[0-9]+.+" # (Optional) Regex used to validate custom commit messages, e.g. requiring an issue key. Default: shown value.
 #      dependency_track: # (Optional) Dependency-Track integration settings. Default: enabled by template.
@@ -249,8 +250,9 @@ repositories:
         disabled: false
       branch:
         protectionEnabled: true
-      enforce:
         conventionalCommitsEnabled: true
+      enforce:
+        conventionalCommitsEnforced: false
       dependency_track:
         disabled: false
         type: "Application"
@@ -327,8 +329,8 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | n/a |
+| <a name="provider_github"></a> [github](#provider\_github) | 6.4.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.12.1 |
 
 ## Modules
 

--- a/README.yaml
+++ b/README.yaml
@@ -98,11 +98,12 @@ usage: |-
   #        dist: "temurin" # (Optional) Runtime distribution when supported. Default: template-specific.
   #      sonarqube: # (Optional) SonarQube integration settings. Default: enabled by template.
   #        disabled: false # (Optional) Disable SonarQube when true. Default: false.
-  #      branch: # (Optional) Branch-protection rendering settings. Default: protection enabled.
+  #      branch: # (Optional) Branch-protection rendering settings. Default: protection enabled, Conventional Commits validation disabled.
   #        protectionEnabled: true # (Optional) Render branch-protection configuration into the CI/CD config. Default: true.
-  #      enforce: # (Optional) Commit-message enforcement settings rendered into the CI/CD config. Default: enforcement disabled.
-  #        conventionalCommitsEnabled: false # (Optional) Enforce Conventional Commits messages when true. Default: false.
+  #        conventionalCommitsEnabled: false # (Optional) Enable Conventional Commits message validation on protected branches. Default: false.
   #        conventionalCommitsPattern: "^(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\([a-z0-9\\-]+\\))?: .+" # (Optional) Regex used to validate Conventional Commits messages. Default: shown value.
+  #      enforce: # (Optional) Commit-message enforcement settings rendered into the CI/CD config. Default: enforcement disabled.
+  #        conventionalCommitsEnforced: false # (Optional) Enforce (block) commits that do not match the Conventional Commits pattern when true. Default: false.
   #        customCommitsPatternEnabled: false # (Optional) Enforce a custom commit-message pattern when true. Default: false.
   #        customCommitsPattern: "PROJECT-[0-9]+.+" # (Optional) Regex used to validate custom commit messages, e.g. requiring an issue key. Default: shown value.
   #      dependency_track: # (Optional) Dependency-Track integration settings. Default: enabled by template.
@@ -199,8 +200,9 @@ examples: |-
           disabled: false
         branch:
           protectionEnabled: true
-        enforce:
           conventionalCommitsEnabled: true
+        enforce:
+          conventionalCommitsEnforced: false
         dependency_track:
           disabled: false
           type: "Application"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,8 +9,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | 6.4.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.12.1 |
+| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,8 +9,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | n/a |
+| <a name="provider_github"></a> [github](#provider\_github) | 6.4.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.12.1 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -103,11 +103,12 @@ locals {
     build        = {}
     sonarqube    = {}
     branch = {
-      protectionEnabled = true
+      protectionEnabled          = true
+      conventionalCommitsEnabled = false
+      conventionalCommitsPattern = "^(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\([a-z0-9\\-]+\\))?: .+"
     }
     enforce = {
-      conventionalCommitsEnabled  = false
-      conventionalCommitsPattern  = "^(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\([a-z0-9\\-]+\\))?: .+"
+      conventionalCommitsEnforced = false
       customCommitsPatternEnabled = false
       customCommitsPattern        = "PROJECT-[0-9]+.+"
     }

--- a/variables-gh.tf
+++ b/variables-gh.tf
@@ -35,11 +35,12 @@
 #         dist: "temurin" # (Optional) Runtime distribution when supported. Default: template-specific.
 #       sonarqube: # (Optional) SonarQube integration settings. Default: enabled by template.
 #         disabled: false # (Optional) Disable SonarQube when true. Default: false.
-#       branch: # (Optional) Branch-protection rendering settings. Default: protection enabled.
+#       branch: # (Optional) Branch-protection rendering settings. Default: protection enabled, Conventional Commits validation disabled.
 #         protectionEnabled: true # (Optional) Render branch-protection configuration into the CI/CD config. Default: true.
-#       enforce: # (Optional) Commit-message enforcement settings rendered into the CI/CD config. Default: enforcement disabled.
-#         conventionalCommitsEnabled: false # (Optional) Enforce Conventional Commits messages when true. Default: false.
+#         conventionalCommitsEnabled: false # (Optional) Enable Conventional Commits message validation on protected branches. Default: false.
 #         conventionalCommitsPattern: "^(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\([a-z0-9\\-]+\\))?: .+" # (Optional) Regex used to validate Conventional Commits messages. Default: shown value.
+#       enforce: # (Optional) Commit-message enforcement settings rendered into the CI/CD config. Default: enforcement disabled.
+#         conventionalCommitsEnforced: false # (Optional) Enforce (block) commits that do not match the Conventional Commits pattern when true. Default: false.
 #         customCommitsPatternEnabled: false # (Optional) Enforce a custom commit-message pattern when true. Default: false.
 #         customCommitsPattern: "PROJECT-[0-9]+.+" # (Optional) Regex used to validate custom commit messages, e.g. requiring an issue key. Default: shown value.
 #       dependency_track: # (Optional) Dependency-Track integration settings. Default: enabled by template.


### PR DESCRIPTION
## Summary

- Move `conventionalCommitsEnabled` and `conventionalCommitsPattern` from `enforce` to `branch` block in `default_cicd_config`
- Rename enforce toggle to `conventionalCommitsEnforced` (default false), separating validation from enforcement
- Sync `branch` and `enforce` documentation in variables-gh.tf, .boilerplate/inputs.yaml, and README

+semver: patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)