### PR TITLE
fix: deep-merge access and contributors in merged_cicd_config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -125,8 +125,15 @@ locals {
   merged_cicd_config = {
     for k, v in local.repos : k => merge(
       local.default_cicd_config,
-      try(v.cicd_config, {}),
       {
+        access = merge(
+          local.default_cicd_config.access,
+          try(v.cicd_config.access, [])
+        )
+        contributors = merge(
+          local.default_cicd_config.contributors,
+          try(v.cicd_config.contributors, {})
+        )
         cd = merge(
           local.default_cicd_config.cd,
           try(v.cicd_config.cd, {})


### PR DESCRIPTION
## Summary

- Explicitly deep-merge `access` with `default_cicd_config.access` per repo
- Explicitly deep-merge `contributors` with `default_cicd_config.contributors` per repo
- Remove the shallow spread of the entire `cicd_config` object so per-repo `access`/`contributors` combine with the module defaults instead of replacing them wholesale, consistent with the `cd`/`gitflow`/`branch`/`enforce` blocks

+semver: fix