### PR TITLE
fix: use toset(concat()) to merge access list in merged_cicd_config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,10 +126,10 @@ locals {
     for k, v in local.repos : k => merge(
       local.default_cicd_config,
       {
-        access = merge(
+        access = toset(concat(
           local.default_cicd_config.access,
           try(v.cicd_config.access, [])
-        )
+        ))
         contributors = merge(
           local.default_cicd_config.contributors,
           try(v.cicd_config.contributors, {})


### PR DESCRIPTION
## Summary

- Replace `merge()` with `toset(concat())` for the `access` block, since `access` is a list (`[]`) and `merge()` only accepts maps/objects
- Correctly combines `default_cicd_config.access` with the per-repo `cicd_config.access` instead of failing on a list type

+semver: fix